### PR TITLE
Add a few potential dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export GRUB_EXTRA ?= hostname=testpc1
 ##
 
 # Intended for production use (assumes nvme)
-teckhost.iso:
+teckhost.iso: iso/preseed.cfg iso/grub-bios.cfg iso/grub-efi.cfg
 	./iso/build_iso \
 	    -s iso/preseed.cfg \
 	    -o teckhost.iso \
@@ -20,7 +20,7 @@ teckhost.iso:
 	    -f iso/grub-bios.cfg -g iso/grub-efi.cfg
 
 # Intended for use with automated testing
-teckhost-%.iso: testseed.cfg
+teckhost-%.iso: testseed.cfg iso/grub-bios.cfg iso/grub-efi.cfg
 	./iso/build_iso \
 	    -s testseed.cfg \
 	    -o teckhost-$(subst teckhost-,,$(subst .iso,,$@)).iso \
@@ -29,7 +29,7 @@ teckhost-%.iso: testseed.cfg
 	    -f iso/grub-bios.cfg -g iso/grub-efi.cfg
 
 # Intended for local developmnt with virtualbox
-teckhost-local.iso: testseed.cfg
+teckhost-local.iso: testseed.cfg iso/grub-bios.cfg iso/grub-efi.cfg
 	./iso/build_iso \
 	    -s testseed.cfg \
 	    -o teckhost-local.iso \
@@ -41,7 +41,7 @@ teckhost-local.iso: testseed.cfg
 # Preeseed
 ##
 
-testseed.cfg:
+testseed.cfg: iso/preseed.cfg test/preseed.patch
 	cp iso/preseed.cfg testseed.cfg
 	patch testseed.cfg test/preseed.patch
 


### PR DESCRIPTION
I'm not familiar with the `build_iso` tool here, but it feels a bit like it's using `iso/grub-bios.cfg` and `iso/grub-efi.cfg` as inputs, and if they are replaced, probably the isos built with them need to be rebuilt as well.

Signed-off-by: Seth Arnold <seth.arnold@gmail.com>

### Tests written

No

### Commits signed with GPG

No